### PR TITLE
Follow patterns of plugin-node-tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,23 @@ function pluginInit (patternlab) {
     }
   }
 
-  registerEvents(patternlab); patternlab.config[pluginName] = true;
+  //setup listeners if not already active. we also enable and set the plugin as initialized
+  if (!patternlab.config.plugins) {
+    patternlab.config.plugins = {};
+  }
+
+  //attempt to only register events once
+  if (
+    patternlab.config.plugins[pluginName] !== undefined &&
+    patternlab.config.plugins[pluginName].enabled &&
+    !patternlab.config.plugins[pluginName].initialized
+  ) {
+    //register events
+    registerEvents(patternlab);
+
+    //set the plugin initialized flag to true to indicate it is installed and ready
+    patternlab.config.plugins[pluginName].initialized = true;
+  }
 }
 
 module.exports = pluginInit


### PR DESCRIPTION
Wrap `registerEvents` as in `plugin-node-tab` examples, and properly set plugin config's `initialized` value to `true` once event is registered (instead of setting a _non-existent value_ on the config to true: `patternlab.config[pluginName] = true`). Let me know if I'm missing any reason for discrepancies with the model pattern. Thanks for the plugin.